### PR TITLE
async/await changes

### DIFF
--- a/src/BullOak.Repositories.EntityFramework.Test.Integration/StepDefinitions/ScenarioSetupAndTeardown.cs
+++ b/src/BullOak.Repositories.EntityFramework.Test.Integration/StepDefinitions/ScenarioSetupAndTeardown.cs
@@ -1,8 +1,5 @@
 ﻿namespace BullOak.Repositories.NEventStore.Test.Integration.StepDefinitions
 {
-    using System.Linq;
-    using System.Reflection;
-    using BullOak.Repositories.EntityFramework;
     using BullOak.Repositories.EntityFramework.Test.Integration.Contexts;
     using BullOak.Repositories.EntityFramework.Test.Integration.DbModel;
     using TechTalk.SpecFlow;

--- a/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
@@ -34,10 +34,10 @@
         }
 
         [Given(@"an existing stream with (.*) events")]
-        public async Task GivenAnExistingStreamWithEvents(int count)
+        public Task GivenAnExistingStreamWithEvents(int count)
         {
             testDataContext.ResetStream();
-            await eventStoreContainer.WriteEventsToStreamRaw(
+            return eventStoreContainer.WriteEventsToStreamRaw(
                 testDataContext.CurrentStreamId,
                 eventGenerator.GenerateEvents(count));
         }

--- a/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/StreamStepsDefinitions.cs
@@ -1,5 +1,4 @@
-﻿
-namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
+﻿namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
 {
     using BullOak.Repositories.EventStore.Test.Integration.Components;
     using BullOak.Repositories.EventStore.Test.Integration.Contexts;
@@ -7,6 +6,7 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
     using FluentAssertions;
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using TechTalk.SpecFlow;
     using Xunit;
 
@@ -34,10 +34,10 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
         }
 
         [Given(@"an existing stream with (.*) events")]
-        public void GivenAnExistingStreamWithEvents(int count)
+        public async Task GivenAnExistingStreamWithEvents(int count)
         {
             testDataContext.ResetStream();
-            eventStoreContainer.WriteEventsToStreamRaw(
+            await eventStoreContainer.WriteEventsToStreamRaw(
                 testDataContext.CurrentStreamId,
                 eventGenerator.GenerateEvents(count));
         }
@@ -51,11 +51,11 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
 
         [Given(@"I try to save the new events in the stream through their interface")]
         [When(@"I try to save the new events in the stream through their interface")]
-        public void GivenITryToSaveTheNewEventsInTheStreamThroughTheirInterface()
+        public async Task GivenITryToSaveTheNewEventsInTheStreamThroughTheirInterface()
         {
-            testDataContext.RecordedException = Record.Exception(() =>
+            testDataContext.RecordedException = await Record.ExceptionAsync(async () => 
             {
-                using (var session = eventStoreContainer.StartSession(testDataContext.CurrentStreamId).Result)
+                using (var session = await eventStoreContainer.StartSession(testDataContext.CurrentStreamId))
                 {
                     foreach (var @event in testDataContext.LastGeneratedEvents)
                     {
@@ -66,19 +66,18 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
                         });
                     }
 
-                    session.SaveChanges().Wait();
+                    await session.SaveChanges();
                 }
             });
         }
 
         [When(@"I try to save the new events in the stream")]
-        public void WhenITryToSaveTheNewEventsInTheStream()
+        public async Task WhenITryToSaveTheNewEventsInTheStream()
         {
-            testDataContext.RecordedException = Record.Exception(() =>
+            testDataContext.RecordedException = await Record.ExceptionAsync(() =>
                 eventStoreContainer.AppendEventsToCurrentStream(
                     testDataContext.CurrentStreamId,
-                    testDataContext.LastGeneratedEvents)
-                .Wait());
+                    testDataContext.LastGeneratedEvents));
         }
 
         [Then(@"the load process should succeed")]
@@ -89,18 +88,18 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
         }
 
         [Then(@"there should be (.*) events in the stream")]
-        public void ThenThereShouldBeEventsInTheStream(int count)
+        public async Task ThenThereShouldBeEventsInTheStream(int count)
         {
-            var recordedEvents = eventStoreContainer.ReadEventsFromStreamRaw(testDataContext.CurrentStreamId);
+            var recordedEvents = await eventStoreContainer.ReadEventsFromStreamRaw(testDataContext.CurrentStreamId);
             recordedEvents.Length.Should().Be(count);
         }
 
         [When(@"I load my entity")]
-        public void WhenILoadMyEntity()
+        public async Task WhenILoadMyEntity()
         {
-            testDataContext.RecordedException = Record.Exception(() =>
+            testDataContext.RecordedException = await Record.ExceptionAsync(async () =>
             {
-                using (var session = eventStoreContainer.StartSession(testDataContext.CurrentStreamId).Result)
+                using (var session = await eventStoreContainer.StartSession(testDataContext.CurrentStreamId))
                 {
                     testDataContext.LatestLoadedState = session.GetCurrentState();
                 }
@@ -114,9 +113,9 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
         }
 
         [When(@"I add (.*) events in the session without saving it")]
-        public void WhenIAddEventsInTheSessionWithoutSavingIt(int eventCount)
+        public async Task WhenIAddEventsInTheSessionWithoutSavingIt(int eventCount)
         {
-            using (var session = eventStoreContainer.StartSession(testDataContext.CurrentStreamId).Result)
+            using (var session = await eventStoreContainer.StartSession(testDataContext.CurrentStreamId))
             {
                 session.AddEvents(eventGenerator.GenerateEvents(eventCount));
 
@@ -125,9 +124,11 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
         }
 
         [Given(@"session '(.*)' is open")]
-        public void GivenSessionIsOpen(string sessionName)
+        public async Task GivenSessionIsOpen(string sessionName)
         {
-            testDataContext.NamedSessions.Add(sessionName, eventStoreContainer.StartSession(testDataContext.CurrentStreamId).Result);
+            testDataContext.NamedSessions.Add(
+                sessionName,
+                await eventStoreContainer.StartSession(testDataContext.CurrentStreamId));
         }
 
         [When(@"I try to add (.*) new events to '(.*)'")]
@@ -138,13 +139,13 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
         }
 
         [When(@"I try to save '(.*)'")]
-        public void WhenITryToSave(string sessionName)
+        public async Task WhenITryToSave(string sessionName)
         {
             if (!testDataContext.NamedSessionsExceptions.ContainsKey(sessionName))
             {
                 testDataContext.NamedSessionsExceptions.Add(sessionName, new List<Exception>());
             }
-            var recordedException = Record.ExceptionAsync(() => testDataContext.NamedSessions[sessionName].SaveChanges()).Result;
+            var recordedException = await Record.ExceptionAsync(() => testDataContext.NamedSessions[sessionName].SaveChanges());
             if (recordedException != null)
             {
                 testDataContext.NamedSessionsExceptions[sessionName].Add(recordedException);

--- a/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/TestsSetupAndTeardown.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/TestsSetupAndTeardown.cs
@@ -5,6 +5,7 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
     using BoDi;
     using BullOak.Repositories.EventStore.Test.Integration.Contexts;
     using System;
+    using System.Threading.Tasks;
     using TechTalk.SpecFlow;
 
     [Binding]
@@ -18,9 +19,9 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
         }
 
         [BeforeTestRun]
-        public static void SetupEventStoreNode()
+        public static async Task SetupEventStoreNode()
         {
-            InProcEventStoreIntegrationContext.SetupNode();
+            await InProcEventStoreIntegrationContext.SetupNode();
         }
 
         [AfterTestRun]

--- a/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/TestsSetupAndTeardown.cs
+++ b/src/BullOak.Repositories.EventStore.Test.Integration/StepDefinitions/TestsSetupAndTeardown.cs
@@ -19,9 +19,9 @@ namespace BullOak.Repositories.EventStore.Test.Integration.StepDefinitions
         }
 
         [BeforeTestRun]
-        public static async Task SetupEventStoreNode()
+        public static Task SetupEventStoreNode()
         {
-            await InProcEventStoreIntegrationContext.SetupNode();
+            return InProcEventStoreIntegrationContext.SetupNode();
         }
 
         [AfterTestRun]

--- a/src/BullOak.Repositories.Test.Acceptance/StepDefinitions/SaveStreamSteps.cs
+++ b/src/BullOak.Repositories.Test.Acceptance/StepDefinitions/SaveStreamSteps.cs
@@ -1,6 +1,7 @@
 ﻿namespace BullOak.Repositories.Test.Acceptance.StepDefinitions
 {
     using System;
+    using System.Threading.Tasks;
     using BullOak.Repositories.Test.Acceptance.Contexts;
     using FluentAssertions;
     using TechTalk.SpecFlow;
@@ -31,13 +32,13 @@
         }
 
         [When(@"I try to save the new events in the stream")]
-        public void WhenITryToSaveTheNewEventsInTheStream()
+        public async Task WhenITryToSaveTheNewEventsInTheStream()
         {
             using (var session = sessionContainer.StartSession(streamInfo.Id))
             {
                 session.AddEvents(eventsContainer.LastEventsCreated);
 
-                recordedException = Record.ExceptionAsync(() => session.SaveChanges()).Result;
+                recordedException = await Record.ExceptionAsync(() => session.SaveChanges());
             }
         }
 


### PR DESCRIPTION
Work done
---

  1. `.Result`/`.Wait()` replaced with `async/await`

  2. Important things to review

- `async/await` usage

Integrity
---

- [x] I have had a look on the PR preview for obvious whitespace\formatting issues before actually openned this PR
- [x] I have run unit tests
- [x] I have run all acceptance tests
- [x] I have run all integration tests
